### PR TITLE
Add tests on settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 JDBC River Plugin for ElasticSearch
 ===================================
 
+// TODO comment fetchsize
+
 Introduction
 ------------
 
@@ -28,7 +30,7 @@ ElasticSearch:
 
 This HTTP PUT statement will create a river named `my_jdbc_river` 
 that fetches all the rows from the `orders` table in the MySQL database 
-`test` at `localhost` and put the documents into 'jdbc/jdbc' index.
+`test` at `localhost` and put the documents into `jdbc/jdbc` index.
 
 You have to install the JDBC driver jar of your favorite database manually into 
 the `plugins/river-jdbc` directory where the jar file of the JDBC river plugin resides.
@@ -208,7 +210,7 @@ will generate fewer JSON objects for the index `relations`.
 	index=relations id=Good {"contact":{"employee":["Müller","Meier","Schulze"],"customer":"Good"}}
 	index=relations id=Bad {"contact":{"employee":"Jones","customer":"Bad"}}
 
-Note how the `employee` column is collapsed into a JSON array. The repeated occurence of the `_id` column
+Note how the `employee` column is collapsed into a JSON array. The repeated occurrence of the `_id` column
 controls how values are folded into arrays for making use of the ElasticSearch JSON data model.
 
 
@@ -229,7 +231,7 @@ ElasticSearch.
 	        "user" : "",
 	        "password" : "",
 	        "sql" : "select products.name as \"product.name\", orders.customer as \"product.customer.name\", orders.quantity * products.price as \"product.customer.bill\" from products, orders where products.name = orders.product and orders.quantity * products.price > ?",
-	        "params: [ 5.0 ]
+	        "params": [ 5.0 ]
 	    }
 	}'
 
@@ -286,7 +288,7 @@ In this example, all rows beginning with a certain date up to now are selected.
 	        "user" : "",
 	        "password" : "",
 	        "sql" : "select products.name as \"product.name\", orders.customer as \"product.customer.name\", orders.quantity * products.price as \"product.customer.bill\" from products, orders where products.name = orders.product and orders.created between ? - 14 and ?",
-	        "params: [ 2012-06-01", "$now" ]
+	        "params": [ "2012-06-01", "$now" ]
 	    }
 	}'
 
@@ -423,7 +425,7 @@ To set up a JDBC river with river table management after creating the river tabl
 	            "max_bulk_requests" : 30,
 	            "bulk_timeout" : "60s"
 	        }
-	    }
+	    }'
 	
 While `poll` is the time between selecting data from the river table, `interval` defines the time span covered for the period being requested by using the column `source_timestamp`. Usually, an additional short time is required to overlap with the `poll` period, here 5 seconds, assuming a river run takes 5 seconds at maximum. If there is no overlap, the risk is that river table entries are being skipped accidentally.
 

--- a/src/test/java/org/elasticsearch/river/jdbc/JDBCRiverTest.java
+++ b/src/test/java/org/elasticsearch/river/jdbc/JDBCRiverTest.java
@@ -1,0 +1,157 @@
+package org.elasticsearch.river.jdbc;
+
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.common.xcontent.XContentHelper;
+import org.elasticsearch.river.RiverName;
+import org.elasticsearch.river.RiverSettings;
+import org.testng.annotations.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.elasticsearch.common.settings.ImmutableSettings.settingsBuilder;
+import static org.testng.Assert.assertTrue;
+
+public class JDBCRiverTest {
+
+    private JDBCRiver river;
+
+
+    @Test
+    public void defaultSettings() throws Exception {
+        // Given
+        String riverName = "my_jdbc_river";
+        String riverIndexName = "_river";
+        String indexName = "jdbc";
+        String typeName = "jdbc";
+        String url = null;
+        String driver = null;
+        String user = null;
+        String password = null;
+        String sql = null;
+        String param = null;
+        int bulkSize = 100;
+        int maxBulkRequests = 30;
+        int fetchsize = 0;
+        String bulkTimeout = "1m";
+        String poll = "1h";
+        String interval = "1h";
+        boolean rivertable = false;
+        boolean versioning = true;
+        String rounding = null;
+        int scale = 0;
+        RiverName rn = new RiverName("jdbc", riverName);
+        final RiverSettings rs = new RiverSettings(settingsBuilder().build(), new HashMap<String, Object>());
+
+        // When
+        river = new JDBCRiver(rn, rs, riverIndexName, null);
+        final String riverSettings = river.toString();
+
+        // Then
+        System.out.println("riverSettings = " + riverSettings);
+        assertTrue(riverSettings.contains("riverIndexName=" + riverIndexName));
+        assertTrue(riverSettings.contains("indexName=" + indexName));
+        assertTrue(riverSettings.contains("typeName=" + typeName));
+        assertTrue(riverSettings.contains("url=" + url));
+        assertTrue(riverSettings.contains("driver=" + driver));
+        assertTrue(riverSettings.contains("user=" + user));
+        assertTrue(riverSettings.contains("password=" + password));
+        assertTrue(riverSettings.contains("sql=" + sql));
+        assertTrue(riverSettings.contains("params=" + param));
+        assertTrue(riverSettings.contains("bulkSize=" + bulkSize));
+        assertTrue(riverSettings.contains("maxBulkRequests=" + maxBulkRequests));
+        assertTrue(riverSettings.contains("fetchsize=" + fetchsize));
+        assertTrue(riverSettings.contains("bulkTimeout=" + bulkTimeout));
+        assertTrue(riverSettings.contains("poll=" + poll));
+        assertTrue(riverSettings.contains("interval=" + interval));
+        assertTrue(riverSettings.contains("versioning=" + versioning));
+        assertTrue(riverSettings.contains("rounding=" + rounding));
+        assertTrue(riverSettings.contains("scale=" + scale));
+        assertTrue(riverSettings.contains("rivertable=" + rivertable));
+    }
+
+    @Test
+    public void allSettingsSet() throws Exception {
+        // Given
+        String riverName = "my_jdbc_river";
+        String riverIndexName = "_river";
+        String indexName = "test";
+        String typeName = "test";
+        String url = "jdbc:mysql://localhost:3306/test";
+        String driver = "com.mysql.jdbc.Driver";
+        String user = "test";
+        String password = "test";
+        String sql = "select * from orders where order.name = ?";
+        String param = "test_param";
+        int bulkSize = 4;
+        int maxBulkRequests = 5;
+        int fetchsize = 6;
+        String bulkTimeout = "2h";
+        String poll = "3h";
+        String interval = "4h";
+        boolean versioning = false;
+        String rounding = "ceiling";
+        int scale = 4;
+        boolean rivertable = true;
+
+        XContentBuilder xb = XContentFactory.jsonBuilder()
+                .startObject()
+                .field("type", "jdbc")
+                .startObject("jdbc")
+                .field("driver", driver)
+                .field("url", url)
+                .field("user", user)
+                .field("password", password)
+                .field("sql", sql)
+                .field("params", param)
+                .field("poll", poll)
+                .field("versioning", versioning)
+                .field("rounding", rounding)
+                .field("scale", scale)
+                .field("fetchsize", fetchsize)
+                .field("rivertable", rivertable)
+                .field("interval", interval)
+                .endObject()
+                .startObject("index")
+                .field("index", indexName)
+                .field("type", typeName)
+                .field("bulk_size", bulkSize)
+                .field("max_bulk_requests", maxBulkRequests)
+                .field("bulk_timeout", bulkTimeout)
+                .endObject()
+                .endObject();
+
+        final byte[] content = xb.copiedBytes();
+        final Map<String, Object> settings = XContentHelper.convertToMap(content, 0, content.length, false).v2();
+        RiverName rn = new RiverName("jdbc", riverName);
+        final RiverSettings rs = new RiverSettings(settingsBuilder().build(), settings);
+
+        // When
+        river = new JDBCRiver(rn, rs, riverIndexName, null);
+        final String riverSettings = river.toString();
+
+        // Then
+        System.out.println("riverSettings = " + riverSettings);
+        assertTrue(riverSettings.contains("riverIndexName=" + riverIndexName));
+        assertTrue(riverSettings.contains("indexName=" + indexName));
+        assertTrue(riverSettings.contains("typeName=" + typeName));
+        assertTrue(riverSettings.contains("url=" + url));
+        assertTrue(riverSettings.contains("driver=" + driver));
+        assertTrue(riverSettings.contains("user=" + user));
+        assertTrue(riverSettings.contains("password=" + password.replaceAll(".", "\\*")));
+        assertTrue(riverSettings.contains("sql=" + sql));
+        assertTrue(riverSettings.contains("params=[" + param + "]"));
+        assertTrue(riverSettings.contains("bulkSize=" + bulkSize));
+        assertTrue(riverSettings.contains("maxBulkRequests=" + maxBulkRequests));
+        assertTrue(riverSettings.contains("fetchsize=" + fetchsize));
+        assertTrue(riverSettings.contains("bulkTimeout=" + bulkTimeout));
+        assertTrue(riverSettings.contains("poll=" + poll));
+        assertTrue(riverSettings.contains("interval=" + interval));
+        assertTrue(riverSettings.contains("versioning=" + versioning));
+        assertTrue(riverSettings.contains("rounding=" + rounding));
+        assertTrue(riverSettings.contains("scale=" + scale));
+        assertTrue(riverSettings.contains("rivertable=" + rivertable));
+    }
+
+}


### PR DESCRIPTION
Hi Jörg, 

I've just add a `JDBCRiverTest` class with tests to check all configuration parameters are correctly set. To do this and in order to prevent using getters I've just implement a `toString` method and check that parameters are correctly set in this string (if you prefer we can define getters).

Furthermore this `toString` may be used to print River JDBC configuration.

Otherwise I've made some minor corrections in README.md.

Cheers

Nicolas
