### PR TITLE
Process columns ending in "__json" as JSON objects, not strings

### DIFF
--- a/src/main/java/org/elasticsearch/river/jdbc/SQLService.java
+++ b/src/main/java/org/elasticsearch/river/jdbc/SQLService.java
@@ -40,6 +40,7 @@ import java.util.LinkedList;
 import java.util.List;
 import org.elasticsearch.action.bulk.BulkItemResponse;
 import org.elasticsearch.common.logging.ESLogger;
+import org.elasticsearch.common.xcontent.json.JsonXContent;
 
 /**
  * The SQL service class manages the SQL access to the JDBC connection.
@@ -277,7 +278,12 @@ public class SQLService implements BulkAcknowledge {
                 case Types.VARCHAR:
                 case Types.LONGVARCHAR: {
                     String s = result.getString(i);
-                    values.add(s);
+                    if (name.endsWith("__json")) {
+                      Object o = JsonXContent.jsonXContent.createParser(s).mapAndClose();
+                      values.add(o);
+                    } else {
+                      values.add(s);
+                    }
                     break;
                 }
                 case Types.NCHAR:

--- a/src/test/java/org/elasticsearch/river/jdbc/MySqlTest.java
+++ b/src/test/java/org/elasticsearch/river/jdbc/MySqlTest.java
@@ -216,5 +216,42 @@ public class MySqlTest {
             e.printStackTrace();
         }
     }    
+
+    @Test
+    public void testJsonParsing() {
+        try {
+            String driverClassName = "com.mysql.jdbc.Driver";
+            String url = "jdbc:mysql://localhost/test";
+            String username = "";
+            String password = "";
+            String sql = "select '{\"A\":\"a\"}' as a__json";
+            List<Object> params = new ArrayList();
+            int fetchsize = 0;
+            Action listener = new DefaultAction() {
+
+                @Override
+                public void index(String index, String type, String id, long version, XContentBuilder builder) throws IOException {
+                    System.err.println("index=" + index + " type=" + type + " id=" + id + " builder=" + builder.string());
+                }
+            };
+            SQLService service = new SQLService();
+            Connection connection = service.getConnection(driverClassName, url, username, password, true);
+            PreparedStatement statement = service.prepareStatement(connection, sql);
+            service.bind(statement, params);
+            ResultSet results = service.execute(statement, fetchsize);
+            Merger merger = new Merger(listener, 1L);
+            long rows = 0L;
+            while (service.nextRow(results, merger)) {
+                rows++;
+            }
+            merger.close();
+            System.err.println("rows = " + rows);
+            service.close(results);
+            service.close(statement);
+            service.close(connection);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
     
 }


### PR DESCRIPTION
This lets you store JSON strings in your database and have Elasticsearch index them as objects.

The code is very rough/hacky and does not include config settings or docs, but I wanted to submit it to see if you had any suggestions/ideas. I'm willing to clean it up and resubmit it if you think it would be useful.

Motivation: We use the PostgreSQL JSON support in PLv8, which means we store JSON strings in our DB. This also would help people who use FriendFeed-style MySQL JSON schemas.
