### PR TITLE
Rework RestJDBCRiverInduceAction

### DIFF
--- a/src/main/java/org/elasticsearch/plugin/river/jdbc/JDBCRiverPlugin.java
+++ b/src/main/java/org/elasticsearch/plugin/river/jdbc/JDBCRiverPlugin.java
@@ -58,7 +58,7 @@ public class JDBCRiverPlugin extends AbstractPlugin {
      * @param module
      */
     public void onModule(RiversModule module) {
-        module.registerRiver("jdbc", JDBCRiverModule.class);
+        module.registerRiver(JDBCRiver.TYPE, JDBCRiverModule.class);
     }
 
     /**

--- a/src/main/java/org/elasticsearch/rest/action/RestJDBCRiverInduceAction.java
+++ b/src/main/java/org/elasticsearch/rest/action/RestJDBCRiverInduceAction.java
@@ -24,71 +24,117 @@ import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.inject.Injector;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.plugins.Plugin;
-import org.elasticsearch.plugins.PluginsService;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestChannel;
 import org.elasticsearch.rest.RestController;
 import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.rest.XContentRestResponse;
 import org.elasticsearch.rest.XContentThrowableRestResponse;
 import org.elasticsearch.rest.action.support.RestXContentBuilder;
+import org.elasticsearch.river.River;
+import org.elasticsearch.river.RiverName;
+import org.elasticsearch.river.RiversService;
 import org.elasticsearch.river.jdbc.JDBCRiver;
 
 import java.io.IOException;
+import java.lang.reflect.Field;
 import java.util.Map;
-
-import static org.elasticsearch.rest.RestRequest.Method.POST;
-import static org.elasticsearch.rest.RestStatus.OK;
 
 /**
  * The JDBC River REST fire move. The river can be fired once to run
  * when this move is called from REST.
- *
- * Example:
- *
- * curl -XPOST 'localhost:9200/my_jdbc_river/_induce'
- *
+ * <p>
+ * Example:<br/>
+ * <code>
+ * curl -XPOST 'localhost:9200/_river/my_jdbc_river/_induce'
+ * </code>
  * @author Jörg Prante <joergprante@gmail.com>
+ * @author pdegeus
  */
 public class RestJDBCRiverInduceAction extends BaseRestHandler {
 
-    private final PluginsService pluginsService;
+    private final RiversService riversService;
 
     @Inject
     public RestJDBCRiverInduceAction(Settings settings, Client client,
                                      RestController controller, Injector injector) {
         super(settings, client);
-        this.pluginsService = injector.getInstance(PluginsService.class);
-        controller.registerHandler(POST, "/{river}/_induce", this);
+        this.riversService = injector.getInstance(RiversService.class);
+        controller.registerHandler(RestRequest.Method.POST, "/_river/{river}/_induce", this);
     }
 
     @Override
     public void handleRequest(final RestRequest request, RestChannel channel) {
+
+        //Get and check river name parameter
         String riverName = request.param("river");
-        ImmutableMap<String, Plugin> plugins = pluginsService.plugins();
-        boolean ok = false;
-        for (Map.Entry<String, Plugin> me : plugins.entrySet()) {
-            if (JDBCRiver.NAME.equals(me.getKey())) {
-                JDBCRiver jdbcRiver = (JDBCRiver) me.getValue();
-                if (jdbcRiver.riverName().name().equals(riverName)) {
-                    jdbcRiver.induce();
-                    ok = true;
+        if (riverName == null || riverName.isEmpty()) {
+            respond(false, request, channel, "Parameter 'river' is required", RestStatus.BAD_REQUEST);
+            return;
+        }
+
+        //Retrieve the registered rivers using reflection (UGLY HACK!!)
+        //TODO: Obtain the rivers using public API
+        ImmutableMap<RiverName, River> rivers;
+        try {
+            Field field = RiversService.class.getDeclaredField("rivers");
+            field.setAccessible(true);
+            rivers = (ImmutableMap<RiverName, River>) field.get(riversService);
+        } catch (NoSuchFieldException e) {
+            errorResponse(request, channel, e);
+            return;
+        } catch (IllegalAccessException e) {
+            errorResponse(request, channel, e);
+            return;
+        }
+
+        boolean found = false;
+        for (Map.Entry<RiverName, River> entry : rivers.entrySet()) {
+            RiverName name = entry.getKey();
+
+            if (name.getName().equals(riverName)) {
+                if (!name.getType().equals(JDBCRiver.TYPE)) {
+                    respond(
+                        false, request, channel,
+                        "River '" + riverName + "' is not a jdbc-river, but has type " + name.getType(),
+                        RestStatus.UNPROCESSABLE_ENTITY
+                    );
+                    return;
                 }
+
+                JDBCRiver jdbcRiver = (JDBCRiver) entry.getValue();
+                jdbcRiver.induce();
+                found = true;
+                break;
             }
         }
+
+        String error = found ? null : "River not found: " + riverName;
+        respond(found, request, channel, error, RestStatus.OK);
+    }
+
+    private void respond(boolean success, RestRequest request, RestChannel channel, String error, RestStatus status) {
         try {
             XContentBuilder builder = RestXContentBuilder.restContentBuilder(request);
             builder.startObject();
-            builder.field("ok", ok);
-            builder.endObject();
-            channel.sendResponse(new XContentRestResponse(request, OK, builder));
-        } catch (IOException e) {
-            try {
-                channel.sendResponse(new XContentThrowableRestResponse(request, e));
-            } catch (IOException e1) {
-                logger.error("Failed to send failure response", e1);
+            builder.field("success", success);
+            if (error != null) {
+                builder.field("error", error);
             }
+            builder.endObject();
+            channel.sendResponse(new XContentRestResponse(request, status, builder));
+        } catch (IOException e) {
+            errorResponse(request, channel, e);
         }
     }
+
+    private void errorResponse(RestRequest request, RestChannel channel, Throwable e) {
+        try {
+            channel.sendResponse(new XContentThrowableRestResponse(request, e));
+        } catch (IOException e1) {
+            logger.error("Failed to send failure response", e1);
+        }
+    }
+
 }

--- a/src/main/java/org/elasticsearch/river/jdbc/JDBCRiver.java
+++ b/src/main/java/org/elasticsearch/river/jdbc/JDBCRiver.java
@@ -49,6 +49,7 @@ import java.util.Map;
 public class JDBCRiver extends AbstractRiverComponent implements River {
 
     public final static String NAME = "jdbc-river";
+    public final static String TYPE = "jdbc";
 
     private final String strategy;
     private final TimeValue poll;
@@ -92,9 +93,9 @@ public class JDBCRiver extends AbstractRiverComponent implements River {
         // riverIndexName = _river
 
         Map<String, Object> sourceSettings =
-                riverSettings.settings().containsKey("jdbc")
-                        ? (Map<String, Object>) riverSettings.settings().get("jdbc")
-                        : new HashMap();
+                riverSettings.settings().containsKey(TYPE)
+                        ? (Map<String, Object>) riverSettings.settings().get(TYPE)
+                        : new HashMap<String, Object>();
         // default is a single run
         strategy = XContentMapValues.nodeStringValue(sourceSettings.get("strategy"), "oneshot");
         url = XContentMapValues.nodeStringValue(sourceSettings.get("url"), null);
@@ -119,9 +120,9 @@ public class JDBCRiver extends AbstractRiverComponent implements River {
         Map<String, Object> targetSettings =
                 riverSettings.settings().containsKey("index")
                         ? (Map<String, Object>) riverSettings.settings().get("index")
-                        : new HashMap();
-        indexName = XContentMapValues.nodeStringValue(targetSettings.get("index"), "jdbc");
-        typeName = XContentMapValues.nodeStringValue(targetSettings.get("type"), "jdbc");
+                        : new HashMap<String, Object>();
+        indexName = XContentMapValues.nodeStringValue(targetSettings.get("index"), TYPE);
+        typeName = XContentMapValues.nodeStringValue(targetSettings.get("type"), TYPE);
         bulkSize = XContentMapValues.nodeIntegerValue(targetSettings.get("bulk_size"), 100);
         maxBulkRequests = XContentMapValues.nodeIntegerValue(targetSettings.get("max_bulk_requests"), 30);
         indexSettings = XContentMapValues.nodeStringValue(targetSettings.get("index_settings"), null);
@@ -205,7 +206,7 @@ public class JDBCRiver extends AbstractRiverComponent implements River {
         if (closed) {
             return;
         }
-        logger.info("closing JDBC river [" + riverName.name() + "/" + strategy + "]");
+        logger.info("closing JDBC river [" + riverName.name() + '/' + strategy + ']');
         if (thread != null) {
             thread.interrupt();
         }
@@ -238,7 +239,7 @@ public class JDBCRiver extends AbstractRiverComponent implements River {
         RiverFlow riverTask = RiverServiceLoader.findRiverFlow(strategy);
         // prepare task for run
         riverTask.riverContext(riverContext);
-        thread = EsExecutors.daemonThreadFactory(settings.globalSettings(), "JDBC river(fired) [" + riverName.name() + "/" + strategy + ")")
+        thread = EsExecutors.daemonThreadFactory(settings.globalSettings(), "JDBC river (fired) [" + riverName.name() + '/' + strategy + ')')
                 .newThread(riverTask);
         riverTask.abort();
         thread.start(); // once


### PR DESCRIPTION
Fixes #14.
Reworked RestJDBCRiverInduceAction to make it do more then throw a ClassCastException.
This implementation involves reflection to get to the registered rivers in ElasticSearch. A solution using some ES API would be much better, but this works.
