### PR TITLE
Fix #50: Plugin blocks startup of cluster by waiting for yellow status

### DIFF
--- a/src/main/java/org/elasticsearch/river/jdbc/JDBCRiver.java
+++ b/src/main/java/org/elasticsearch/river/jdbc/JDBCRiver.java
@@ -197,7 +197,7 @@ public class JDBCRiver extends AbstractRiverComponent implements River {
                 return;
             }
         }
-        thread = EsExecutors.daemonThreadFactory(settings.globalSettings(), "JDBC river [" + riverName.name() + "/" + strategy + ")")
+        thread = EsExecutors.daemonThreadFactory(settings.globalSettings(), "JDBC river [" + riverName.name() + '/' + strategy + ']')
                 .newThread(riverFlow);
         thread.start();
     }

--- a/src/main/java/org/elasticsearch/river/jdbc/strategy/simple/SimpleRiverFlow.java
+++ b/src/main/java/org/elasticsearch/river/jdbc/strategy/simple/SimpleRiverFlow.java
@@ -114,8 +114,9 @@ public class SimpleRiverFlow implements RiverFlow {
             logger.info("{}, waiting {}", reason, poll);
             try {
                 Thread.sleep(poll.millis());
-            } catch (InterruptedException e1) {
-                // ignore
+            } catch (InterruptedException e) {
+                logger.debug("Thread interrupted while waiting, stopping");
+                abort();
             }
         }
         return this;
@@ -134,7 +135,7 @@ public class SimpleRiverFlow implements RiverFlow {
      */
     @Override
     public void run() {
-        while (true) {
+        while (!abort) {
             move();
             if (abort) {
                 return;

--- a/src/main/java/org/elasticsearch/river/jdbc/support/HealthMonitorThread.java
+++ b/src/main/java/org/elasticsearch/river/jdbc/support/HealthMonitorThread.java
@@ -1,0 +1,79 @@
+package org.elasticsearch.river.jdbc.support;
+
+import java.lang.Runnable;
+import java.lang.Thread;
+
+import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.common.logging.ESLogger;
+import org.elasticsearch.common.logging.ESLoggerFactory;
+import org.elasticsearch.common.unit.TimeValue;
+
+/**
+ * Cluster health monitor thread. Checks the cluster status every 5 minutes and is used by
+ * all JDBC river mouths to check if actions should be performed.
+ * @author pdegeus
+ */
+public class HealthMonitorThread implements Runnable {
+
+    private static final ESLogger LOG = ESLoggerFactory.getLogger(HealthMonitorThread.class.getName());
+
+    private boolean stop = false;
+    private boolean healthy = false;
+    private final Client client;
+
+    /**
+     * Constructor.
+     * @param client Client instance to check health with.
+     */
+    public HealthMonitorThread(Client client) {
+        this.client = client;
+    }
+
+    @Override
+    public void run() {
+        while (!stop) {
+            healthy = false;
+            int curTime = 0;
+
+            while (!healthy) {
+                ClusterHealthResponse health = client.admin().cluster().prepareHealth()
+                    .setWaitForYellowStatus()
+                    .setTimeout(TimeValue.timeValueMinutes(1))
+                    .execute().actionGet();
+
+                if (health.timedOut()) {
+                    LOG.info("Waiting for cluster ({} minutes elapsed)...", curTime);
+                    curTime++;
+                } else {
+                    healthy = true;
+                }
+            }
+
+            try {
+                Thread.sleep(TimeValue.timeValueMinutes(5).getMillis());
+            } catch (InterruptedException e) {
+                Thread.interrupted();
+                if (!stop) {
+                    LOG.warn("Thread interrupted unexpectedly, stopping", e);
+                    stop = true;
+                }
+            }
+        }
+    }
+
+    /**
+     * Stops this thread.
+     */
+    public void stop() {
+        stop = true;
+    }
+
+    /**
+     * @return True if the cluster is healthy.
+     */
+    public boolean isHealthy() {
+        return healthy;
+    }
+
+}


### PR DESCRIPTION
- Monitor cluster health in a separate thread and always wait for status yellow before doing anything. The cluster health is checked every 5 minutes and all actions (index, delete) are blocked until health is yellow.
- Fixes stacktrace on node shutdown.
