### PR TITLE
Not closing the Statement leaks cursors with Oracle in executeQuery(String) method

### DIFF
--- a/src/main/java/org/xbib/elasticsearch/river/jdbc/RiverSource.java
+++ b/src/main/java/org/xbib/elasticsearch/river/jdbc/RiverSource.java
@@ -163,14 +163,6 @@ public interface RiverSource {
     ResultSet executeQuery(PreparedStatement statement) throws SQLException;
 
     /**
-     * Execute query without binding parameters
-     * @param sql the SQL statement
-     * @return the result set
-     * @throws SQLException
-     */
-    ResultSet executeQuery(String sql) throws SQLException;
-
-    /**
      * Execute insert/update
      * @param statement
      * @return this river source

--- a/src/main/java/org/xbib/elasticsearch/river/jdbc/strategy/simple/SimpleRiverSource.java
+++ b/src/main/java/org/xbib/elasticsearch/river/jdbc/strategy/simple/SimpleRiverSource.java
@@ -378,23 +378,6 @@ public class SimpleRiverSource implements RiverSource {
         return set;
     }
 
-    /**
-     * Execute query statement
-     *
-     * @param sql
-     * @return the result set
-     * @throws SQLException
-     */
-    @Override
-    public ResultSet executeQuery(String sql) throws SQLException {
-        Statement statement = connectionForReading().createStatement();
-        statement.setMaxRows(context.maxRows());
-        statement.setFetchSize(context.fetchSize());
-        logger.debug("executing SQL {}", sql);
-        ResultSet set = statement.executeQuery(sql);
-        return set;
-    }
-
 
     /**
      * Execute prepared update statement


### PR DESCRIPTION
I noticed a problem when implementing our own strategy using Oracle. The symptom was an SQLException with message ORA-01000: maximum open cursors exceeded. A little debugging lead me to the executeQuery(String) method which apparently leaves the Statement open even after the ResultSet is closed.

Looking through the code it seemed that using the executeQuery(PreparedStatement) method does exactly the same as the now unused executeQuery(String) method did except for using a different Statement. I removed the (String)-method with the comment about PostgreSQL as the fetchsize was set in both methods.
