### PR TITLE
Check fields for json before treating them as normal strings. This allows us to mix normal fields with json fields.

### DIFF
--- a/src/main/java/org/xbib/elasticsearch/river/jdbc/strategy/simple/SimpleValueListener.java
+++ b/src/main/java/org/xbib/elasticsearch/river/jdbc/strategy/simple/SimpleValueListener.java
@@ -168,8 +168,13 @@ public class SimpleValueListener<O extends Object> implements ValueListener {
         }
         // create current object from values by sequentially merging the values
         for (int i = 0; i < keys.size(); i++) {
-            Map m = merge(current.source(), keys.get(i), values.get(i));
-            current.source(m);
+        	Map map = null;
+        	try {
+        		map = JsonXContent.jsonXContent.createParser(values.get(i).toString()).mapAndClose();
+        	} catch (Exception e) {}
+        	
+        	Map m = merge(current.source(), keys.get(i), map != null && map.size() > 0 ? map : values.get(i));
+    		current.source(m);
         }
         return this;
     }


### PR DESCRIPTION
Right now jdbc river allows either _source field or normal fields.
There is no way of having both normal fields and json fields. This
commit fixes this issue by trying to convert each field to json if it
has valid json string.
