### PR TITLE
Fix for timestamped indexes #272

### DIFF
--- a/src/main/java/org/xbib/elasticsearch/plugin/feeder/jdbc/JDBCFeeder.java
+++ b/src/main/java/org/xbib/elasticsearch/plugin/feeder/jdbc/JDBCFeeder.java
@@ -226,7 +226,7 @@ public class JDBCFeeder<T, R extends PipelineRequest, P extends Pipeline<T, R>>
         riverMouth.setTimeWindowed(timeWindowed)
                 .setIndex(defaultIndex)
                 .setType(defaultType)
-                .setIngest(ingest);                ;
+                .setIngest(ingest);
         riverFlow.setFeeder(this);
         this.riverContext = new RiverContext()
                 .setRiverName(riverName)


### PR DESCRIPTION
Update to fix bug when using timestamped indexes (index_timestamp)

Index name was being set before the timestamp pattern had been resolved, and so was creating a literal index name.
e.g. index-YYYY-MM-dd instead of index-2014-06-28

Changed the order to set timeWindowed before before index name
