### PR TITLE
Overlap time for JDBC river column strategy

### DIFF
--- a/src/main/java/org/xbib/elasticsearch/plugin/jdbc/RiverContext.java
+++ b/src/main/java/org/xbib/elasticsearch/plugin/jdbc/RiverContext.java
@@ -127,6 +127,11 @@ public class RiverContext {
     private String columnDeletedAt;
 
     /**
+     * Contains overlap value for last run timestamp.
+     */
+    private TimeValue lastRunTimeStampOverlap;
+
+    /**
      * Columns name should be automatically escaped by proper db quote mark or not (for column strategy)
      */
     private boolean columnEscape;
@@ -434,6 +439,15 @@ public class RiverContext {
 
     public boolean columnEscape() {
         return this.columnEscape;
+    }
+
+    public TimeValue getLastRunTimeStampOverlap() {
+        return lastRunTimeStampOverlap;
+    }
+
+    public RiverContext setLastRunTimeStampOverlap(TimeValue lastRunTimeStampOverlap) {
+        this.lastRunTimeStampOverlap = lastRunTimeStampOverlap;
+        return this;
     }
 
     public RiverContext contextualize() {

--- a/src/main/java/org/xbib/elasticsearch/river/jdbc/strategy/column/ColumnRiverFeeder.java
+++ b/src/main/java/org/xbib/elasticsearch/river/jdbc/strategy/column/ColumnRiverFeeder.java
@@ -42,11 +42,14 @@ public class ColumnRiverFeeder<T, R extends PipelineRequest, P extends Pipeline<
         String columnUpdatedAt = XContentMapValues.nodeStringValue(mySettings.get("updated_at"), "updated_at");
         String columnDeletedAt = XContentMapValues.nodeStringValue(mySettings.get("deleted_at"), null);
         boolean columnEscape = XContentMapValues.nodeBooleanValue(mySettings.get("column_escape"), true);
+        TimeValue lastRunTimeStampOverlap = XContentMapValues.nodeTimeValue(mySettings.get("last_run_timestamp_overlap"),
+            TimeValue.timeValueSeconds(0));
         riverContext
                 .columnCreatedAt(columnCreatedAt)
                 .columnUpdatedAt(columnUpdatedAt)
                 .columnDeletedAt(columnDeletedAt)
-                .columnEscape(columnEscape);
+                .columnEscape(columnEscape)
+                .setLastRunTimeStampOverlap(lastRunTimeStampOverlap);
     }
 
         @Override

--- a/src/main/java/org/xbib/elasticsearch/river/jdbc/strategy/column/ColumnRiverSource.java
+++ b/src/main/java/org/xbib/elasticsearch/river/jdbc/strategy/column/ColumnRiverSource.java
@@ -91,7 +91,7 @@ public class ColumnRiverSource extends SimpleRiverSource {
             return new Timestamp(0);
         }
         TimeValue lastRunTime = (TimeValue) settings.get(ColumnRiverFlow.LAST_RUN_TIME);
-        return new Timestamp(lastRunTime.millis());
+        return new Timestamp(lastRunTime.millis() - context.getLastRunTimeStampOverlap().millis());
     }
 
     private void fetch(Connection connection, SQLCommand command, OpInfo opInfo, Timestamp lastRunTimestamp) throws IOException, SQLException {

--- a/src/test/resources/org/xbib/elasticsearch/river/jdbc/strategy/column/derby/river-existedWhereClauseWithOverlap.json
+++ b/src/test/resources/org/xbib/elasticsearch/river/jdbc/strategy/column/derby/river-existedWhereClauseWithOverlap.json
@@ -1,0 +1,15 @@
+{
+    "jdbc" : {
+        "strategy" : "column",
+        "url" : "jdbc:derby:memory:myDB",
+        "user" : "",
+        "password" : "",
+        "sql": "SELECT \"id\", \"name\" FROM \"products\" WHERE 1=1",
+        "column_updated_at": "updated_at",
+        "column_created_at": "created_at",
+        "column_deleted_at": "deleted_at",
+        "last_run_timestamp_overlap" : "0.5s",
+        "index" : "my_jdbc_river_index",
+        "type" : "my_jdbc_river_type"
+    }
+}

--- a/src/test/resources/org/xbib/elasticsearch/river/jdbc/strategy/column/h2/river-existedWhereClauseWithOverlap.json
+++ b/src/test/resources/org/xbib/elasticsearch/river/jdbc/strategy/column/h2/river-existedWhereClauseWithOverlap.json
@@ -1,0 +1,15 @@
+{
+    "jdbc" : {
+        "strategy" : "column",
+        "url" : "jdbc:h2:target/test?TRACE_LEVEL_FILE=target/trace",
+        "user" : "",
+        "password" : "",
+        "sql": "SELECT \"id\", \"name\" FROM \"products\" WHERE 1=1",
+        "column_updated_at": "updated_at",
+        "column_created_at": "created_at",
+        "column_deleted_at": "deleted_at",
+        "last_run_timestamp_overlap" : "0.5s",
+        "index" : "my_jdbc_river_index",
+        "type" : "my_jdbc_river_type"
+    }
+}

--- a/src/test/resources/org/xbib/elasticsearch/river/jdbc/strategy/column/hsqldb/river-existedWhereClauseWithOverlap.json
+++ b/src/test/resources/org/xbib/elasticsearch/river/jdbc/strategy/column/hsqldb/river-existedWhereClauseWithOverlap.json
@@ -1,0 +1,15 @@
+{
+    "jdbc" : {
+        "strategy" : "column",
+        "url" : "jdbc:hsqldb:mem:test",
+        "user" : "sa",
+        "password" : "",
+        "sql": "SELECT \"id\", \"name\" FROM \"products\" WHERE 1=1",
+        "column_updated_at": "updated_at",
+        "column_created_at": "created_at",
+        "column_deleted_at": "deleted_at",
+        "last_run_timestamp_overlap" : "0.5s",
+        "index" : "my_jdbc_river_index",
+        "type" : "my_jdbc_river_type"
+    }
+}

--- a/src/test/resources/org/xbib/elasticsearch/river/jdbc/strategy/column/mysql/river-existedWhereClauseWithOverlap.json
+++ b/src/test/resources/org/xbib/elasticsearch/river/jdbc/strategy/column/mysql/river-existedWhereClauseWithOverlap.json
@@ -1,0 +1,15 @@
+{
+    "jdbc" : {
+        "strategy" : "column",
+        "url" : "jdbc:mysql://localhost:3306/test",
+        "user" : "",
+        "password" : "",
+        "sql": "SELECT id, name FROM products WHERE 1=1",
+        "column_updated_at": "updated_at",
+        "column_created_at": "created_at",
+        "column_deleted_at": "deleted_at",
+        "last_run_timestamp_overlap" : "0.5s",
+        "index" : "my_jdbc_river_index",
+        "type" : "my_jdbc_river_type"
+    }
+}

--- a/src/test/resources/org/xbib/elasticsearch/river/jdbc/strategy/column/postgresql/river-existedWhereClauseWithOverlap.json
+++ b/src/test/resources/org/xbib/elasticsearch/river/jdbc/strategy/column/postgresql/river-existedWhereClauseWithOverlap.json
@@ -1,0 +1,15 @@
+{
+    "jdbc" : {
+        "strategy" : "column",
+        "url" : "jdbc:postgresql://localhost:5432/test",
+        "user" : "test",
+        "password" : "test",
+        "sql": "SELECT \"id\", \"name\" FROM \"products\" WHERE 1=1",
+        "column_updated_at": "updated_at",
+        "column_created_at": "created_at",
+        "column_deleted_at": "deleted_at",
+        "last_run_timestamp_overlap" : "0.5s",
+        "index" : "my_jdbc_river_index",
+        "type" : "my_jdbc_river_type"
+    }
+}

--- a/src/test/resources/testsuite/column/derby.xml
+++ b/src/test/resources/testsuite/column/derby.xml
@@ -15,6 +15,7 @@
         <parameter name="river-sqlForTestDeletions" value="derby/river-sqlForTestDeletions.json"/>
         <parameter name="river-sqlForTestDeletionsAndWherePlaceholder" value="derby/river-sqlForTestDeletionsAndWherePlaceholder.json"/>
         <parameter name="river-whereClausePlaceholder" value="derby/river-whereClausePlaceholder.json"/>
+        <parameter name="river-existedWhereClauseWithOverlap" value="derby/river-existedWhereClauseWithOverlap.json"/>
         <parameter name="river-sqlparams" value="derby/river-sqlparams.json"/>
         <parameter name="sqlInsert"
                     value="insert into &quot;products&quot; (&quot;id&quot;, &quot;name&quot;, &quot;amount&quot;, &quot;price&quot;, &quot;created_at&quot;, &quot;updated_at&quot;, &quot;deleted_at&quot;) VALUES(?,?,?,?,?,?,?)" />

--- a/src/test/resources/testsuite/column/h2.xml
+++ b/src/test/resources/testsuite/column/h2.xml
@@ -14,6 +14,7 @@
         <parameter name="river-sqlForTestDeletions" value="h2/river-sqlForTestDeletions.json"/>
         <parameter name="river-sqlForTestDeletionsAndWherePlaceholder" value="h2/river-sqlForTestDeletionsAndWherePlaceholder.json"/>
         <parameter name="river-whereClausePlaceholder" value="h2/river-whereClausePlaceholder.json"/>
+        <parameter name="river-existedWhereClauseWithOverlap" value="h2/river-existedWhereClauseWithOverlap.json"/>
         <parameter name="river-sqlparams" value="h2/river-sqlparams.json"/>
         <parameter name="sqlInsert"
                     value="insert into &quot;products&quot; (&quot;id&quot;, &quot;name&quot;, &quot;amount&quot;, &quot;price&quot;, &quot;created_at&quot;, &quot;updated_at&quot;, &quot;deleted_at&quot;) VALUES(?,?,?,?,?,?,?)" />

--- a/src/test/resources/testsuite/column/hsqldb.xml
+++ b/src/test/resources/testsuite/column/hsqldb.xml
@@ -14,6 +14,7 @@
         <parameter name="river-sqlForTestDeletions" value="hsqldb/river-sqlForTestDeletions.json"/>
         <parameter name="river-sqlForTestDeletionsAndWherePlaceholder" value="hsqldb/river-sqlForTestDeletionsAndWherePlaceholder.json"/>
         <parameter name="river-whereClausePlaceholder" value="hsqldb/river-whereClausePlaceholder.json"/>
+        <parameter name="river-existedWhereClauseWithOverlap" value="hsqldb/river-existedWhereClauseWithOverlap.json"/>
         <parameter name="river-sqlparams" value="hsqldb/river-sqlparams.json"/>
         <parameter name="sqlInsert"
                     value="insert into &quot;products&quot; (&quot;id&quot;, &quot;name&quot;, &quot;amount&quot;, &quot;price&quot;, &quot;created_at&quot;, &quot;updated_at&quot;, &quot;deleted_at&quot;) VALUES(?,?,?,?,?,?,?)" />

--- a/src/test/resources/testsuite/column/mysql.xml
+++ b/src/test/resources/testsuite/column/mysql.xml
@@ -67,6 +67,7 @@
         <parameter name="river-sqlForTestDeletions" value="mysql/river-sqlForTestDeletions.json"/>
         <parameter name="river-sqlForTestDeletionsAndWherePlaceholder" value="mysql/river-sqlForTestDeletionsAndWherePlaceholder.json"/>
         <parameter name="river-whereClausePlaceholder" value="mysql/river-whereClausePlaceholder.json"/>
+        <parameter name="river-existedWhereClauseWithOverlap" value="mysql/river-existedWhereClauseWithOverlap.json"/>
         <parameter name="river-sqlparams" value="mysql/river-sqlparams.json"/>
         <parameter name="sqlInsert"
                     value="insert into products (id, name, amount, price, created_at, updated_at, deleted_at) VALUES(?,?,?,?,?,?,?)" />

--- a/src/test/resources/testsuite/column/postgresql.xml
+++ b/src/test/resources/testsuite/column/postgresql.xml
@@ -14,6 +14,7 @@
         <parameter name="river-sqlForTestDeletions" value="postgresql/river-sqlForTestDeletions.json"/>
         <parameter name="river-sqlForTestDeletionsAndWherePlaceholder" value="postgresql/river-sqlForTestDeletionsAndWherePlaceholder.json"/>
         <parameter name="river-whereClausePlaceholder" value="postgresql/river-whereClausePlaceholder.json"/>
+        <parameter name="river-existedWhereClauseWithOverlap" value="postgresql/river-existedWhereClauseWithOverlap.json"/>
         <parameter name="river-sqlparams" value="postgresql/river-sqlparams.json"/>
         <parameter name="sqlInsert"
                     value="insert into &quot;products&quot; (&quot;id&quot;, &quot;name&quot;, &quot;amount&quot;, &quot;price&quot;, &quot;created_at&quot;, &quot;updated_at&quot;, &quot;deleted_at&quot;) VALUES(?,?,?,?,?,?,?)" />


### PR DESCRIPTION
We observed that river sometimes used to lose records from database which had the update date very colse to the time when the river was scheduled to run. As a fix we implemented the possibility to define in the river configuration the "last_run_timestamp_overlap" parameter. It affects the river queries to ask for records with defined overlap instead of strictly from the time of last run time.
