### PR TITLE
#287 - used getName() instead of hardcoded value "feeder"

### DIFF
--- a/src/main/java/org/xbib/elasticsearch/river/jdbc/strategy/column/ColumnRiverFeeder.java
+++ b/src/main/java/org/xbib/elasticsearch/river/jdbc/strategy/column/ColumnRiverFeeder.java
@@ -54,7 +54,7 @@ public class ColumnRiverFeeder<T, R extends PipelineRequest, P extends Pipeline<
     @Override
     public void executeTask(Map<String, Object> map) throws Exception {
         logger.info("processing map {}", map);
-        createRiverContext("jdbc", "feeder", map);
+        createRiverContext("jdbc", getName(), map);
         if (riverState == null) {
             riverState = new RiverState();
         }


### PR DESCRIPTION
I guess this hardcoded value is a bug.
