### PR TITLE
Properly identify SQL statements of form UPDATE....SELECT as non-query.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -343,6 +343,23 @@
         </profile>
 
         <profile>
+            <id>test-plugin</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <skipTests>false</skipTests>
+                            <suiteXmlFiles>
+                                <suiteXmlFile>${basedir}/src/test/resources/testsuite/plugin/plugin.xml</suiteXmlFile>
+                            </suiteXmlFiles>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <profile>
             <id>test-derby</id>
             <dependencies>
                 <dependency>

--- a/src/main/java/org/xbib/elasticsearch/plugin/jdbc/SQLCommand.java
+++ b/src/main/java/org/xbib/elasticsearch/plugin/jdbc/SQLCommand.java
@@ -13,6 +13,7 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Pattern;
 
 /**
  * The SQL command
@@ -20,6 +21,8 @@ import java.util.Map;
 public class SQLCommand {
 
     private String sql;
+
+    private static final Pattern STATEMENT_PATTERN = Pattern.compile("^\\s*(update|insert)",Pattern.CASE_INSENSITIVE);
 
     private List<Object> params = new LinkedList<Object>();
 
@@ -62,6 +65,9 @@ public class SQLCommand {
     public boolean isQuery() {
         if (sql == null) {
             throw new IllegalArgumentException("no SQL found");
+        }
+        if (STATEMENT_PATTERN.matcher(sql).find()) {
+            return false;
         }
         int p1 = sql.toLowerCase().indexOf("select");
         if (p1 < 0) {

--- a/src/test/java/org/xbib/elasticsearch/river/plugin/SQLCommandTests.java
+++ b/src/test/java/org/xbib/elasticsearch/river/plugin/SQLCommandTests.java
@@ -1,0 +1,46 @@
+package org.xbib.elasticsearch.river.plugin;
+
+import java.io.IOException;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import org.xbib.elasticsearch.plugin.jdbc.SQLCommand;
+
+public class SQLCommandTests extends Assert {
+ 		@Test
+ 		public void simpleQuery() throws IOException {
+ 			SQLCommand sc = new SQLCommand().setSQL("select * from table");
+ 			assertTrue(sc.isQuery());
+ 		}
+
+ 		@Test
+ 		public void updateQueryType() throws IOException {
+ 			SQLCommand sc = new SQLCommand().setSQL("update foo");
+ 			assertFalse(sc.isQuery());
+ 		}
+
+ 		@Test
+ 		public void updateWithSubselect() throws IOException {
+ 			SQLCommand sc = new SQLCommand().setSQL("update foo set thingie = select");
+ 			assertFalse(sc.isQuery());
+ 		}
+
+ 		@Test
+ 		public void updateWithSubselectAndLeadingWhitespace() throws IOException {
+ 			SQLCommand sc = new SQLCommand().setSQL("   update foo set thingie = select");
+ 			assertFalse(sc.isQuery());
+ 		}
+
+ 		@Test
+ 		public void updateUpperCaseWithSelect() throws IOException {
+ 			SQLCommand sc = new SQLCommand().setSQL("UPDATE foo set thingie = SELECT");
+ 			assertFalse(sc.isQuery());
+ 		}
+
+ 		@Test
+ 		public void insertWithSelect() throws IOException {
+ 			SQLCommand sc = new SQLCommand().setSQL("insert into foo values select * from bar");
+ 			assertFalse(sc.isQuery());
+ 		}
+}

--- a/src/test/resources/testsuite/plugin/plugin.xml
+++ b/src/test/resources/testsuite/plugin/plugin.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd">
+
+<suite name="JDBC River Test Suite (plugin)" verbose="1">
+
+    <test name="Plugin Tests">
+        <classes>
+            <class name="org.xbib.elasticsearch.river.plugin.SQLCommandTests"/>
+        </classes>
+    </test>
+
+</suite>


### PR DESCRIPTION
Current implementation of isQuery() does not identify SQL of the form:

```
UPDATE foo 
set <whatever,whatever,whatever>
where foo.<somefield> in (SELECT <somefield> from bar....)
```

as a non-query, requiring both a r/w connection and not returning a record count.

Pull req. adds a precedence check for SQL r/w verbs to flag these properly, along with some unit tests in the "test-plugin" profile.
