### PR TITLE
#287 Fixed the river name issue for the column strategy

### DIFF
--- a/src/main/java/org/xbib/elasticsearch/plugin/feeder/jdbc/JDBCFeeder.java
+++ b/src/main/java/org/xbib/elasticsearch/plugin/feeder/jdbc/JDBCFeeder.java
@@ -61,6 +61,7 @@ public class JDBCFeeder<T, R extends PipelineRequest, P extends Pipeline<T, R>>
 
     public JDBCFeeder(JDBCFeeder feeder) {
         super(feeder);
+        this.name = feeder.getName();
     }
 
     @Override

--- a/src/test/java/org/xbib/elasticsearch/river/jdbc/strategy/column/ColumnRiverFlowTests.java
+++ b/src/test/java/org/xbib/elasticsearch/river/jdbc/strategy/column/ColumnRiverFlowTests.java
@@ -54,13 +54,14 @@ public class ColumnRiverFlowTests extends AbstractRiverNodeTest {
         RiverFlow flow = new ColumnRiverFlow();
         flow.setRiverContext(context);
         flow.getFeeder()
+                .setName(context.getRiverName())
                 .setRiverState(new RiverState())
                 .setSpec(spec)
                 .setSettings(settings)
                 .setClient(client)
                 .run();
-        // we can no longer test this, as _river index is always deleted between test runs!
-        //assertLastRiverRunTimeExists(client);
+        client.admin().indices().refresh(Requests.refreshRequest("_river")).actionGet();
+        assertLastRiverRunTimeExists(client);
     }
 
     @Test()


### PR DESCRIPTION
The constructor for JDBCFeeder initializes the object just by calling the super constructor. What about the fields contained directly by this class like 'name'? So, I added initialization for the 'name' field, but there are also others.
