### PR TITLE
add * to 'chmod 644 /plugins/jdbc/' to set correct perms on jbdc/

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ Internet access (of course)
 5. Add MySQL JDBC driver jar to JDBC river plugin directory and set access permission for .jar file (at least chmod 644)
 
 	`cp mysql-connector-java-5.1.33-bin.jar $ES_HOME/plugins/jdbc/`
-	`chmod 644 $ES_HOME/plugins/jdbc/`
+	`chmod 644 $ES_HOME/plugins/jdbc/*`
 
 6. Start elasticsearch from terminal window
 


### PR DESCRIPTION
Hi, executing the chmod command in the readme instructions will remove the executable bit on $ES_HOME/plugins/jdbc and it's contents which causes the .jars to not be found by ES and this terrible java error to be thrown: 
'NoClassSettingsException[Failed to load class with value [jdbc]'

I've added an asterisk to the chmod command so it executes on the contents of $ES_HOME/plugins/jdbc/ instead of the directory itself.  
