### PR TITLE
Fix for #487 - Modified equals method to use compareTo in addition to comparing hashcode

### DIFF
--- a/src/main/java/org/xbib/elasticsearch/plugin/jdbc/util/PlainIndexableObject.java
+++ b/src/main/java/org/xbib/elasticsearch/plugin/jdbc/util/PlainIndexableObject.java
@@ -238,7 +238,7 @@ public class PlainIndexableObject implements IndexableObject, ToXContent, Compar
 
     @Override
     public boolean equals(Object o) {
-        return o != null && o instanceof IndexableObject && this.compareTo((IndexableObject)o) == 0;
+        return o != null && o instanceof IndexableObject && hashCode() == o.hashCode() && this.compareTo((IndexableObject)o) == 0;
     }
 
     @Override

--- a/src/main/java/org/xbib/elasticsearch/plugin/jdbc/util/PlainIndexableObject.java
+++ b/src/main/java/org/xbib/elasticsearch/plugin/jdbc/util/PlainIndexableObject.java
@@ -238,7 +238,7 @@ public class PlainIndexableObject implements IndexableObject, ToXContent, Compar
 
     @Override
     public boolean equals(Object o) {
-        return o != null && o instanceof IndexableObject && hashCode() == o.hashCode();
+        return o != null && o instanceof IndexableObject && this.compareTo((IndexableObject)o) == 0;
     }
 
     @Override


### PR DESCRIPTION
Changed PlainIndexableObject equals implementation to compare the fields rather than use hashcode. This prevents different ids with conflicting hashcode from being considered equal.