### PR TITLE
Fix plugin download URL in Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ will be supported.
 
 ## Installation
 
-    ./bin/plugin --install jdbc --url http://xbib.org/repository/org/xbib/elasticsearch/plugin/elasticsearch-river-jdbc/1.5.0.4/elasticsearch-river-jdbc-1.5.0.4.zip
+    ./bin/plugin --install jdbc --url http://xbib.org/repository/org/xbib/elasticsearch/plugin/elasticsearch-river-jdbc/1.5.0.4/elasticsearch-river-jdbc-1.5.0.4-plugin.zip
 
 Do not forget to restart the node after installing.
 


### PR DESCRIPTION
Readme.md was missing the word "plugin" in the download URL
