### PR TITLE
Add option to pass JSON file as configuration to feeder.

### DIFF
--- a/README.md
+++ b/README.md
@@ -522,10 +522,44 @@ Here is an example of a feeder bash script:
             "index" : "metawiki"
           }
     }
-    ' | java \
-        -cp "${DIR}/*" \
+    ' | java -cp "${DIR}/*" \
         org.xbib.elasticsearch.plugin.jdbc.feeder.Runner \
         org.xbib.elasticsearch.plugin.jdbc.feeder.JDBCFeeder
+
+or you can add the feeder configuration in a JSON file and pass it as argument to the command:
+
+    #!/bin/sh
+
+    DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+    
+    # ES_HOME required to detect elasticsearch jars
+    export ES_HOME=~es/elasticsearch-1.4.0.Beta1
+    
+    java -cp "${DIR}/*" \
+        org.xbib.elasticsearch.plugin.jdbc.feeder.Runner \
+        org.xbib.elasticsearch.plugin.jdbc.feeder.JDBCFeeder \
+        feederinput.json
+
+
+**feederinput.json**
+    
+    {
+        "elasticsearch" : {
+             "cluster" : "elasticsearch",
+             "host" : "localhost",
+             "port" : 9300
+        },
+        "type" : "jdbc",
+        "jdbc" : {
+            "url" : "jdbc:mysql://localhost:3306/test",
+            "user" : "",
+            "password" : "",
+            "sql" :  "select *, page_id as _id from page",
+            "treat_binary_as_string" : true,
+            "index" : "metawiki"
+        }
+    }
+    
 
 How does it work?
 

--- a/src/main/java/org/xbib/elasticsearch/plugin/jdbc/feeder/JDBCFeeder.java
+++ b/src/main/java/org/xbib/elasticsearch/plugin/jdbc/feeder/JDBCFeeder.java
@@ -40,24 +40,12 @@ import org.xbib.elasticsearch.plugin.jdbc.state.RiverStatesMetaData;
 import org.xbib.elasticsearch.plugin.jdbc.util.RiverServiceLoader;
 import org.xbib.elasticsearch.river.jdbc.RiverFlow;
 
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.io.OutputStreamWriter;
-import java.io.PrintStream;
-import java.io.Reader;
-import java.io.Writer;
+import java.io.*;
 import java.security.Security;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ConcurrentLinkedDeque;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
-import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.ScheduledThreadPoolExecutor;
-import java.util.concurrent.ThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.*;
 
 import static org.elasticsearch.common.collect.Lists.newLinkedList;
 import static org.elasticsearch.common.settings.ImmutableSettings.settingsBuilder;
@@ -115,8 +103,8 @@ public class JDBCFeeder {
      *
      * @throws Exception
      */
-    public void exec() throws Exception {
-        readFrom(new InputStreamReader(System.in, "UTF-8"))
+    public void exec(Reader reader) throws Exception {
+        readFrom(reader)
                 .writeTo(new OutputStreamWriter(System.out, "UTF-8"))
                 .errorsTo(System.err)
                 .start();


### PR DESCRIPTION
I made a change to make it possible to pass a JSON file as argument to the runner/application.  That keeps the shell script to start clean.  This makes it also possible to use a single shell script to start feeders with multiple configurations.

