### PR TITLE
upgrade elasticsearch.version from 1.7.0 to 1.7.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
         <github.global.server>github</github.global.server>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.compiler.version>1.7</java.compiler.version>
-        <elasticsearch.version>1.7.0</elasticsearch.version>
+        <elasticsearch.version>1.7.1</elasticsearch.version>
         <org.xbib.elasticsearch.support.version>1.7.0.0</org.xbib.elasticsearch.support.version>
     </properties>
 


### PR DESCRIPTION
upgrade elasticsearch.version from 1.7.0 to 1.7.1 to fix "no cluster nodes available"  when connecting to ElasticSearch 1.7.1
