### PR TITLE
Fixes #648 : Shutdown ingest while it can't be properly build.

### DIFF
--- a/src/main/java/org/xbib/elasticsearch/jdbc/strategy/standard/StandardContext.java
+++ b/src/main/java/org/xbib/elasticsearch/jdbc/strategy/standard/StandardContext.java
@@ -433,11 +433,17 @@ public class StandardContext<S extends JDBCSource> implements Context<S, Sink> {
                         settingsBuilder.put("transport.found." + entry.getKey(), entry.getValue());
                     }
                 }
-                ingest.maxActionsPerBulkRequest(maxbulkactions)
-                        .maxConcurrentBulkRequests(maxconcurrentbulkrequests)
-                        .maxVolumePerBulkRequest(maxvolume)
-                        .flushIngestInterval(flushinterval)
-                        .newClient(settingsBuilder.build());
+                try {
+                    ingest.maxActionsPerBulkRequest(maxbulkactions)
+                            .maxConcurrentBulkRequests(maxconcurrentbulkrequests)
+                            .maxVolumePerBulkRequest(maxvolume)
+                            .flushIngestInterval(flushinterval)
+                            .newClient(settingsBuilder.build());
+                } catch (Exception e) {
+                    logger.error("ingest not properly build, shutting down ingest",e);
+                    ingest.shutdown();
+                    ingest = null;
+                }
                 return ingest;
             }
         };

--- a/src/main/java/org/xbib/elasticsearch/jdbc/strategy/standard/StandardSink.java
+++ b/src/main/java/org/xbib/elasticsearch/jdbc/strategy/standard/StandardSink.java
@@ -92,7 +92,9 @@ public class StandardSink<C extends StandardContext> implements Sink<C> {
         if (ingest == null) {
             if (context.getIngestFactory() != null) {
                 ingest = context.getIngestFactory().create();
-                ingest.setMetric(metric);
+                if(ingest != null) {
+                    ingest.setMetric(metric);
+                }
             } else {
                 logger.warn("no ingest factory found");
             }


### PR DESCRIPTION
Fixes a resource leak which occurs when elasticsearch can't be reached.