### PR TITLE
@Override annotation should be used where necessary

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,7 @@ language: java
 jdk:
   - oraclejdk8
 
-script: ./bin/travis/run-tests.sh
+before_script:
+  - echo "MAVEN_OPTS='-Xmx4096m -Xms4096m'" > ~/.mavenrc
+
+script: travis_wait ./bin/travis/run-tests.sh

--- a/src/main/java/org/xbib/elasticsearch/common/metrics/SinkMetric.java
+++ b/src/main/java/org/xbib/elasticsearch/common/metrics/SinkMetric.java
@@ -2,6 +2,7 @@ package org.xbib.elasticsearch.common.metrics;
 
 public class SinkMetric extends ElasticsearchIngestMetric {
 
+    @Override
     public SinkMetric start() {
         super.start();
         return this;

--- a/src/main/java/org/xbib/elasticsearch/common/util/PlainKeyValueStreamListener.java
+++ b/src/main/java/org/xbib/elasticsearch/common/util/PlainKeyValueStreamListener.java
@@ -232,6 +232,7 @@ public class PlainKeyValueStreamListener<K, V> implements KeyValueStreamListener
      * @return this value listener
      * @throws java.io.IOException if this method fails
      */
+    @Override
     public KeyValueStreamListener<K, V> end() throws IOException {
         if (prev != null) {
             prev.source(current.source());

--- a/src/main/java/org/xbib/elasticsearch/common/util/SinkKeyValueStreamListener.java
+++ b/src/main/java/org/xbib/elasticsearch/common/util/SinkKeyValueStreamListener.java
@@ -32,16 +32,19 @@ public class SinkKeyValueStreamListener<K, V> extends PlainKeyValueStreamListene
         return this;
     }
 
+    @Override
     public SinkKeyValueStreamListener<K, V> shouldIgnoreNull(boolean shouldIgnoreNull) {
         super.shouldIgnoreNull(shouldIgnoreNull);
         return this;
     }
 
+    @Override
     public SinkKeyValueStreamListener<K, V> shouldDetectGeo(boolean shouldDetectGeo) {
         super.shouldDetectGeo(shouldDetectGeo);
         return this;
     }
 
+    @Override
     public SinkKeyValueStreamListener<K, V> shouldDetectJson(boolean shouldDetectJson) {
         super.shouldDetectJson(shouldDetectJson);
         return this;
@@ -54,6 +57,7 @@ public class SinkKeyValueStreamListener<K, V> extends PlainKeyValueStreamListene
      * @return this value listener
      * @throws java.io.IOException if this method fails
      */
+    @Override
     public SinkKeyValueStreamListener<K, V> end(IndexableObject object) throws IOException {
         if (object.isEmpty()) {
             return this;

--- a/src/main/java/org/xbib/elasticsearch/jdbc/strategy/JDBCSource.java
+++ b/src/main/java/org/xbib/elasticsearch/jdbc/strategy/JDBCSource.java
@@ -42,6 +42,7 @@ public interface JDBCSource<C extends Context> extends Source<C> {
      *
      * @return a new source instance
      */
+    @Override
     JDBCSource<C> newInstance();
 
     /**
@@ -50,6 +51,7 @@ public interface JDBCSource<C extends Context> extends Source<C> {
      * @param context the context
      * @return this source
      */
+    @Override
     JDBCSource<C> setContext(C context);
 
     /**

--- a/src/main/java/org/xbib/elasticsearch/jdbc/strategy/standard/StandardContext.java
+++ b/src/main/java/org/xbib/elasticsearch/jdbc/strategy/standard/StandardContext.java
@@ -371,6 +371,7 @@ public class StandardContext<S extends JDBCSource> implements Context<S, Sink> {
 
     private final static MetricsLogger metricsLogger = new MetricsLogger();
 
+    @Override
     public void log() {
         try {
             if (source != null) {
@@ -385,6 +386,7 @@ public class StandardContext<S extends JDBCSource> implements Context<S, Sink> {
     }
 
     class MetricsThread extends Thread {
+        @Override
         public void run() {
             log();
         }

--- a/src/main/java/org/xbib/elasticsearch/jdbc/strategy/standard/StandardSource.java
+++ b/src/main/java/org/xbib/elasticsearch/jdbc/strategy/standard/StandardSource.java
@@ -218,6 +218,7 @@ public class StandardSource<C extends StandardContext> implements JDBCSource<C> 
         return this;
     }
 
+    @Override
     public StandardSource<C> setAutoCommit(boolean autocommit) {
         this.autocommit = autocommit;
         return this;
@@ -227,6 +228,7 @@ public class StandardSource<C extends StandardContext> implements JDBCSource<C> 
         return autocommit;
     }
 
+    @Override
     public StandardSource<C>  setFetchSize(int fetchSize) {
         this.fetchSize = fetchSize;
         return this;
@@ -236,6 +238,7 @@ public class StandardSource<C extends StandardContext> implements JDBCSource<C> 
         return fetchSize;
     }
 
+    @Override
     public StandardSource<C>  setMaxRows(int maxRows) {
         this.maxRows = maxRows;
         return this;
@@ -245,6 +248,7 @@ public class StandardSource<C extends StandardContext> implements JDBCSource<C> 
         return maxRows;
     }
 
+    @Override
     public StandardSource<C>  setRetries(int retries) {
         this.retries = retries;
         return this;
@@ -254,6 +258,7 @@ public class StandardSource<C extends StandardContext> implements JDBCSource<C> 
         return retries;
     }
 
+    @Override
     public StandardSource<C>  setMaxRetryWait(TimeValue maxretrywait) {
         this.maxretrywait = maxretrywait;
         return this;
@@ -263,6 +268,7 @@ public class StandardSource<C extends StandardContext> implements JDBCSource<C> 
         return maxretrywait;
     }
 
+    @Override
     public StandardSource<C>  setRounding(String rounding) {
         if ("ceiling".equalsIgnoreCase(rounding)) {
             this.rounding = BigDecimal.ROUND_CEILING;
@@ -288,6 +294,7 @@ public class StandardSource<C extends StandardContext> implements JDBCSource<C> 
         return rounding;
     }
 
+    @Override
     public StandardSource<C>  setScale(int scale) {
         this.scale = scale;
         return this;
@@ -297,6 +304,7 @@ public class StandardSource<C extends StandardContext> implements JDBCSource<C> 
         return scale;
     }
 
+    @Override
     public StandardSource<C>  setResultSetType(String resultSetType) {
         this.resultSetType = resultSetType;
         return this;
@@ -306,6 +314,7 @@ public class StandardSource<C extends StandardContext> implements JDBCSource<C> 
         return resultSetType;
     }
 
+    @Override
     public StandardSource<C>  setResultSetConcurrency(String resultSetConcurrency) {
         this.resultSetConcurrency = resultSetConcurrency;
         return this;
@@ -315,6 +324,7 @@ public class StandardSource<C extends StandardContext> implements JDBCSource<C> 
         return resultSetConcurrency;
     }
 
+    @Override
     public StandardSource<C> shouldIgnoreNull(boolean shouldIgnoreNull) {
         this.shouldIgnoreNull = shouldIgnoreNull;
         return this;
@@ -324,6 +334,7 @@ public class StandardSource<C extends StandardContext> implements JDBCSource<C> 
         return shouldIgnoreNull;
     }
 
+    @Override
     public StandardSource<C> shouldDetectGeo(boolean shouldDetectGeo) {
         this.shouldDetectGeo = shouldDetectGeo;
         return this;
@@ -333,6 +344,7 @@ public class StandardSource<C extends StandardContext> implements JDBCSource<C> 
         return shouldDetectGeo;
     }
 
+    @Override
     public StandardSource<C> shouldDetectJson(boolean shouldDetectJson) {
         this.shouldDetectJson = shouldDetectJson;
         return this;
@@ -342,6 +354,7 @@ public class StandardSource<C extends StandardContext> implements JDBCSource<C> 
         return shouldDetectJson;
     }
 
+    @Override
     public StandardSource<C> shouldPrepareResultSetMetadata(boolean shouldPrepareResultSetMetadata) {
         this.shouldPrepareResultSetMetadata = shouldPrepareResultSetMetadata;
         return this;
@@ -351,6 +364,7 @@ public class StandardSource<C extends StandardContext> implements JDBCSource<C> 
         return shouldPrepareResultSetMetadata;
     }
 
+    @Override
     public StandardSource<C> shouldPrepareDatabaseMetadata(boolean shouldPrepareDatabaseMetadata) {
         this.shouldPrepareDatabaseMetadata = shouldPrepareDatabaseMetadata;
         return this;
@@ -387,6 +401,7 @@ public class StandardSource<C extends StandardContext> implements JDBCSource<C> 
         return lastRowCount;
     }
 
+    @Override
     public StandardSource<C>  setColumnNameMap(Map<String, Object> columnNameMap) {
         this.columnNameMap = columnNameMap;
         return this;
@@ -405,6 +420,7 @@ public class StandardSource<C extends StandardContext> implements JDBCSource<C> 
         return lastRow;
     }
 
+    @Override
     public StandardSource<C> setStatements(List<SQLCommand> sql) {
         this.sql = sql;
         return this;
@@ -423,6 +439,7 @@ public class StandardSource<C extends StandardContext> implements JDBCSource<C> 
         return isTimestampDiffSupported;
     }
 
+    @Override
     public StandardSource<C> setQueryTimeout(int queryTimeout) {
         this.queryTimeout = queryTimeout;
         return this;
@@ -432,6 +449,7 @@ public class StandardSource<C extends StandardContext> implements JDBCSource<C> 
         return queryTimeout;
     }
 
+    @Override
     public StandardSource<C> setConnectionProperties(Map<String, Object> connectionProperties) {
         this.connectionProperties = connectionProperties;
         return this;
@@ -441,6 +459,7 @@ public class StandardSource<C extends StandardContext> implements JDBCSource<C> 
         return connectionProperties;
     }
 
+    @Override
     public StandardSource<C> shouldTreatBinaryAsString(boolean shouldTreatBinaryAsString) {
         this.shouldTreatBinaryAsString = shouldTreatBinaryAsString;
         return this;

--- a/src/main/java/org/xbib/pipeline/AbstractPipeline.java
+++ b/src/main/java/org/xbib/pipeline/AbstractPipeline.java
@@ -29,6 +29,7 @@ public abstract class AbstractPipeline<R extends PipelineRequest>
         return this;
     }
 
+    @Override
     public BlockingQueue<R> getQueue() {
         return queue;
     }

--- a/src/main/java/org/xbib/tools/JDBCImporter.java
+++ b/src/main/java/org/xbib/tools/JDBCImporter.java
@@ -158,6 +158,7 @@ public class JDBCImporter extends Importer {
 
     public Thread shutdownHook() {
         return new Thread() {
+            @Override
             public void run() {
                 try {
                     shutdown();
@@ -169,6 +170,7 @@ public class JDBCImporter extends Importer {
         };
     }
 
+    @Override
     public synchronized void shutdown() throws Exception {
         if (closed) {
             return;

--- a/src/test/java/org/xbib/elasticsearch/common/util/StringKeyValueStreamListener.java
+++ b/src/test/java/org/xbib/elasticsearch/common/util/StringKeyValueStreamListener.java
@@ -39,6 +39,7 @@ public class StringKeyValueStreamListener extends PlainKeyValueStreamListener<St
      * @return this value listener
      * @throws IOException
      */
+    @Override
     public StringKeyValueStreamListener end(IndexableObject object) throws IOException {
         if (object.isEmpty()) {
             return this;

--- a/src/test/java/org/xbib/elasticsearch/jdbc/strategy/column/ColumnStrategySourceTests.java
+++ b/src/test/java/org/xbib/elasticsearch/jdbc/strategy/column/ColumnStrategySourceTests.java
@@ -155,6 +155,7 @@ public class ColumnStrategySourceTests extends AbstractColumnStrategyTest {
         assertEquals(sink.data().size(), expectedHits);
     }
 
+    @Override
     protected ColumnContext createContext(String resource) throws IOException {
         Settings settings = createSettings(resource);
         ColumnContext context = newContext();

--- a/src/test/java/org/xbib/elasticsearch/jdbc/strategy/standard/StandardCounterTests.java
+++ b/src/test/java/org/xbib/elasticsearch/jdbc/strategy/standard/StandardCounterTests.java
@@ -35,6 +35,7 @@ public class StandardCounterTests extends AbstractSinkTest {
         return new StandardContext();
     }
 
+    @Override
     protected void perform(String resource) throws Exception {
         // perform a single step
         logger.info("before execution, resetting counter");

--- a/src/test/java/org/xbib/elasticsearch/jdbc/strategy/standard/StandardScheduleTests.java
+++ b/src/test/java/org/xbib/elasticsearch/jdbc/strategy/standard/StandardScheduleTests.java
@@ -82,6 +82,7 @@ public class StandardScheduleTests extends AbstractSinkTest {
         importer.setContext(context);
         // dispatch in new thread
         new Thread() {
+            @Override
             public void run() {
                 importer.run(true);
             }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1161 - 
@Override annotation should be used on any method overriding (since Java 5) or implementing (since Java 6) another 

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS1161

Please let me know if you have any questions.

Kirill Vlasov
