### PR TITLE
Throwable and Error should not be caught

### DIFF
--- a/src/main/java/org/xbib/elasticsearch/common/util/PlainIndexableObject.java
+++ b/src/main/java/org/xbib/elasticsearch/common/util/PlainIndexableObject.java
@@ -165,7 +165,7 @@ public class PlainIndexableObject implements IndexableObject, ToXContent, Compar
             } else {
                 try {
                     builder.value(o);
-                } catch (Throwable e) {
+                } catch (Exception e) {
                     throw new IOException("unknown object class for value:" + o.getClass().getName() + " " + o);
                 }
             }

--- a/src/main/java/org/xbib/elasticsearch/jdbc/strategy/standard/StandardContext.java
+++ b/src/main/java/org/xbib/elasticsearch/jdbc/strategy/standard/StandardContext.java
@@ -186,7 +186,7 @@ public class StandardContext<S extends JDBCSource> implements Context<S, Sink> {
         logger.debug("fetch");
         try {
             getSource().fetch();
-        } catch (Throwable e) {
+        } catch (Exception e) {
             setThrowable(e);
             logger.error(e.getMessage(), e);
         }
@@ -198,13 +198,13 @@ public class StandardContext<S extends JDBCSource> implements Context<S, Sink> {
         writeState();
         try {
             getSource().afterFetch();
-        } catch (Throwable e) {
+        } catch (Exception e) {
             setThrowable(e);
             logger.error(e.getMessage(), e);
         }
         try {
             getSink().afterFetch();
-        } catch (Throwable e) {
+        } catch (Exception e) {
             setThrowable(e);
             logger.error(e.getMessage(), e);
         }

--- a/src/main/java/org/xbib/elasticsearch/jdbc/strategy/standard/StandardSource.java
+++ b/src/main/java/org/xbib/elasticsearch/jdbc/strategy/standard/StandardSource.java
@@ -929,7 +929,7 @@ public class StandardSource<C extends StandardContext> implements JDBCSource<C> 
                     logger.debug("registerOutParameter: n={} type={}", n, toJDBCType(type));
                     try {
                         statement.registerOutParameter(n, toJDBCType(type));
-                    } catch (Throwable t) {
+                    } catch (Exception e) {
                         logger.warn("can't register out parameter " + n + " of type " + type);
                     }
                 }

--- a/src/main/java/org/xbib/pipeline/AbstractPipeline.java
+++ b/src/main/java/org/xbib/pipeline/AbstractPipeline.java
@@ -53,7 +53,7 @@ public abstract class AbstractPipeline<R extends PipelineRequest>
             close();
         } catch (InterruptedException e) {
             logger.warn("interrupted");
-        } catch (Throwable t) {
+        } catch (Exception t) {
             logger.error(t.getMessage(), t);
             throw t;
         }

--- a/src/main/java/org/xbib/tools/Importer.java
+++ b/src/main/java/org/xbib/tools/Importer.java
@@ -146,7 +146,7 @@ public abstract class Importer
             } else {
                 execute();
             }
-        } catch (Throwable e) {
+        } catch (Exception e) {
             logger.error(e.getMessage(), e);
         } finally {
             try {
@@ -154,7 +154,7 @@ public abstract class Importer
                 if (executor != null) {
                     executor.shutdown();
                 }
-            } catch (Throwable e) {
+            } catch (Exception e) {
                 logger.warn(e.getMessage(), e);
             }
         }
@@ -165,7 +165,7 @@ public abstract class Importer
         try {
             prepare();
             execute();
-        } catch (Throwable e) {
+        } catch (Exception e) {
             logger.error(e.getMessage(), e);
         } finally {
             try {
@@ -173,7 +173,7 @@ public abstract class Importer
                 if (executor != null) {
                     executor.shutdown();
                 }
-            } catch (Throwable e) {
+            } catch (Exception e) {
                 logger.warn(e.getMessage(), e);
             }
         }

--- a/src/main/java/org/xbib/tools/Runner.java
+++ b/src/main/java/org/xbib/tools/Runner.java
@@ -27,7 +27,7 @@ public class Runner {
             InputStream in = args.length > 1 ? new FileInputStream(args[1]) : System.in;
             commandLineInterpreter.reader("args", in).run(true);
             in.close();
-        } catch (Throwable e) {
+        } catch (Exception e) {
             e.printStackTrace();
             System.exit(1);
         }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1181 - Throwable and Error should not be caught

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS1181

Please let me know if you have any questions.

Kirill Vlasov
