### PR TITLE
when $metrics.lastexecutionstart is null, set it to 0

### DIFF
--- a/bin/mysql-blog.sh
+++ b/bin/mysql-blog.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+bin=${DIR}/../bin
+lib=${DIR}/../lib
+
+echo '
+{
+    "type" : "jdbc",
+    "jdbc" : {
+        "url" : "jdbc:mysql://localhost:3306/blog",
+        "statefile" : "statefile.json",
+        "schedule" : "0 0-59 0-23 ? * *",
+        "user" : "blog",
+        "password" : "12345678",
+        "sql" : [{
+                "statement": "select id as _id, id, post_title as title, post_content as content from wp_posts where post_status = ? and post_modified > ? ",
+                "parameter": ["publish", "$metrics.lastexecutionstart"]}
+            ],
+        "index" : "article",
+        "type" : "blog",
+        "metrics": {
+            "enabled" : true
+        },
+        "elasticsearch" : {
+             "cluster" : "elasticsearch",
+             "host" : "localhost",
+             "port" : 9300 
+        }   
+    }
+}
+' | java \
+    -cp "${lib}/*" \
+    -Dlog4j.configurationFile=${bin}/log4j2.xml \
+    org.xbib.tools.Runner \
+    org.xbib.tools.JDBCImporter

--- a/src/main/java/org/xbib/elasticsearch/jdbc/strategy/standard/StandardSource.java
+++ b/src/main/java/org/xbib/elasticsearch/jdbc/strategy/standard/StandardSource.java
@@ -1296,7 +1296,7 @@ public class StandardSource<C extends StandardContext> implements JDBCSource<C> 
                 statement.setString(i, ExceptionFormatter.format(context.getThrowable()));
             } else if ("$metrics.lastexecutionstart".equals(s)) {
                 DateTime dateTime = sourceMetric != null ? sourceMetric.getLastExecutionStart() : null;
-                statement.setTimestamp(i, dateTime != null ? new Timestamp(dateTime.getMillis()) : null);
+                statement.setTimestamp(i, dateTime != null ? new Timestamp(dateTime.getMillis()) : new Timestamp(new DateTime(0).getMillis()));
             } else if ("$metrics.lastexecutionend".equals(s)) {
                 DateTime dateTime = sourceMetric != null ? sourceMetric.getLastExecutionEnd() : null;
                 statement.setTimestamp(i, dateTime != null ? new Timestamp(dateTime.getMillis()) : null);


### PR DESCRIPTION
When $metrics.lastexecutionstart is null, set it to 0, so we can do a full-import. This is useful when select incremental data from a table.