### PR TITLE
Moved metrics update to finally block to assure consistency of timestamps between SQL calls

### DIFF
--- a/src/main/java/org/xbib/elasticsearch/jdbc/strategy/standard/StandardSource.java
+++ b/src/main/java/org/xbib/elasticsearch/jdbc/strategy/standard/StandardSource.java
@@ -598,8 +598,6 @@ public class StandardSource<C extends StandardContext> implements JDBCSource<C> 
                     }
                     if (sourceMetric != null) {
                         sourceMetric.getSucceeded().inc();
-                        sourceMetric.setLastExecutionStart(dateTime);
-                        sourceMetric.setLastExecutionEnd(new DateTime());
                     }
                 } catch (SQLRecoverableException e) {
                     long millis = getMaxRetryWait().getMillis();
@@ -617,21 +615,19 @@ public class StandardSource<C extends StandardContext> implements JDBCSource<C> 
                     }
                     if (sourceMetric != null) {
                         sourceMetric.getSucceeded().inc();
-                        sourceMetric.setLastExecutionStart(dateTime);
-                        sourceMetric.setLastExecutionEnd(new DateTime());
                     }
                 }
             }
         } catch (Exception e) {
             if (sourceMetric != null) {
                 sourceMetric.getFailed().inc();
-                sourceMetric.setLastExecutionStart(dateTime);
-                sourceMetric.setLastExecutionEnd(new DateTime());
             }
             throw new IOException(e);
         } finally {
             if (sourceMetric != null) {
                 sourceMetric.incCounter();
+                sourceMetric.setLastExecutionStart(dateTime);
+                sourceMetric.setLastExecutionEnd(new DateTime());
             }
         }
     }

--- a/src/main/java/org/xbib/tools/CommandLineInterpreter.java
+++ b/src/main/java/org/xbib/tools/CommandLineInterpreter.java
@@ -16,9 +16,10 @@
 package org.xbib.tools;
 
 import java.io.InputStream;
+import java.util.List;
 
 public interface CommandLineInterpreter {
 
-    void run(String resourceName, InputStream in) throws Exception;
+    void run(String resourceName, List<InputStream> in) throws Exception;
 
 }

--- a/src/main/java/org/xbib/tools/JDBCImporter.java
+++ b/src/main/java/org/xbib/tools/JDBCImporter.java
@@ -18,6 +18,7 @@ package org.xbib.tools;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.settings.Settings.Builder;
 import org.elasticsearch.common.unit.TimeValue;
 import org.xbib.elasticsearch.common.cron.CronExpression;
 import org.xbib.elasticsearch.common.cron.CronThreadPoolExecutor;
@@ -116,11 +117,15 @@ public class JDBCImporter
         return this;
     }
 
-    @Override
-    public void run(String resourceName, InputStream in) {
-        setSettings(settingsBuilder().loadFromStream(resourceName, in).build());
-        run();
-    }
+	@Override
+	public void run(String resourceName, List<InputStream> in) {
+		Builder builder = settingsBuilder();
+		for (int i = 0; i < in.size(); i++) {
+			builder.loadFromStream(resourceName, in.get(i));
+		}
+		setSettings(builder.build());
+		run();
+	}
 
     @Override
     public void run() {

--- a/src/main/java/org/xbib/tools/Runner.java
+++ b/src/main/java/org/xbib/tools/Runner.java
@@ -17,21 +17,32 @@ package org.xbib.tools;
 
 import java.io.FileInputStream;
 import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 public class Runner {
 
-    public static void main(String[] args) {
-        try {
-            Class clazz = Class.forName(args[0]);
-            CommandLineInterpreter commandLineInterpreter = (CommandLineInterpreter) clazz.newInstance();
-            InputStream in = args.length > 1 ? new FileInputStream(args[1]) : System.in;
-            commandLineInterpreter.run("args", in);
-            in.close();
-        } catch (Throwable e) {
-            e.printStackTrace();
-            System.exit(1);
-        }
-        System.exit(0);
-    }
+	public static void main(String[] args) {
+		try {
+			Class clazz = Class.forName(args[0]);
+			CommandLineInterpreter commandLineInterpreter = (CommandLineInterpreter) clazz.newInstance();
+			List<InputStream> inputs = new ArrayList<InputStream>();
+			if (args.length > 1) {
+				for (int i = 1; i < args.length; i++) {
+					inputs.add(new FileInputStream(args[i]));
+				}
+			} else {
+				inputs.add(System.in);
+			}
+			InputStream in = args.length > 1 ? new FileInputStream(args[1]) : System.in;
+			commandLineInterpreter.run("args", inputs);
+			in.close();
+		} catch (Throwable e) {
+			e.printStackTrace();
+			System.exit(1);
+		}
+		System.exit(0);
+	}
 
 }


### PR DESCRIPTION
This addresses issue https://github.com/jprante/elasticsearch-jdbc/issues/683

Timestamps are set after execution insteed of setting in for-loop.
