### PR TITLE
Move logging to slf4j

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,7 @@ ext {
       'elasticsearch' : '2.3.4',
       'elasticsearch-helper' : '2.3.4.0',
       'log4j': '2.5',
+      'slf4j': '1.7.23',
       'wagon' : '2.10',
       'jsr166e': '1.1.0',
       'jna' : '4.1.0',
@@ -83,8 +84,7 @@ configurations {
 dependencies {
     compile 'org.elasticsearch:elasticsearch:' + versions.elasticsearch
     compile 'org.xbib.elasticsearch.plugin:elasticsearch-helper:' + versions.'elasticsearch-helper'
-    compile 'org.apache.logging.log4j:log4j-slf4j-impl:' + versions.log4j
-    compile 'org.apache.logging.log4j:log4j-core:'+ versions.log4j
+    compile 'org.slf4j:slf4j-api:' + versions.slf4j
     compile('com.vividsolutions:jts:' + versions.jts) {
         exclude group: 'xerces'
     }
@@ -93,12 +93,13 @@ dependencies {
     // Workaround for a known issue with TestNG 6.x: explicitly add Guice (Gradle will fail to run tests otherwise)
     testCompile 'com.google.inject:guice:3.0'
     testCompile 'org.uncommons:reportng:1.1.4'
-    testCompile 'org.apache.logging.log4j:log4j-slf4j-impl:' + versions.log4j
-    testCompile 'org.apache.logging.log4j:log4j-core:'+ versions.log4j
+    compile 'org.slf4j:slf4j-api:' + versions.slf4j
     integrationTestCompile 'org.testng:testng:' + versions.testng
     integrationTestCompile 'org.elasticsearch:elasticsearch:' + versions.elasticsearch
     integrationTestCompile 'net.java.dev.jna:jna:' + versions.jna
     // for distribution
+    driverJars 'org.apache.logging.log4j:log4j-slf4j-impl:' + versions.log4j
+    driverJars 'org.apache.logging.log4j:log4j-core:'+ versions.log4j
     driverJars('org.xbib.jdbc:jdbc-driver-csv:' + versions.'jdbc-driver-csv') {
         exclude group: 'org.apache.logging.log4j'
     }

--- a/src/main/java/org/xbib/elasticsearch/common/metrics/MetricsLogger.java
+++ b/src/main/java/org/xbib/elasticsearch/common/metrics/MetricsLogger.java
@@ -15,10 +15,10 @@
  */
 package org.xbib.elasticsearch.common.metrics;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.xbib.elasticsearch.common.util.FormatUtil;
 
 import java.text.NumberFormat;
@@ -27,13 +27,13 @@ import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
 
 public class MetricsLogger {
 
-    private final static Logger plainsourcelogger = LogManager.getLogger("metrics.source.plain");
+    private final static Logger plainsourcelogger = LoggerFactory.getLogger("metrics.source.plain");
 
-    private final static Logger plainsinklogger = LogManager.getLogger("metrics.sink.plain");
+    private final static Logger plainsinklogger = LoggerFactory.getLogger("metrics.sink.plain");
 
-    private final static Logger jsonsourcelogger = LogManager.getLogger("metrics.source.json");
+    private final static Logger jsonsourcelogger = LoggerFactory.getLogger("metrics.source.json");
 
-    private final static Logger jsonsinklogger = LogManager.getLogger("metrics.sink.json");
+    private final static Logger jsonsinklogger = LoggerFactory.getLogger("metrics.sink.json");
 
     private final static NumberFormat formatter = NumberFormat.getNumberInstance();
 

--- a/src/main/java/org/xbib/elasticsearch/jdbc/strategy/column/ColumnSource.java
+++ b/src/main/java/org/xbib/elasticsearch/jdbc/strategy/column/ColumnSource.java
@@ -15,9 +15,9 @@
  */
 package org.xbib.elasticsearch.jdbc.strategy.column;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.joda.time.DateTime;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.xbib.elasticsearch.common.keyvalue.KeyValueStreamListener;
 import org.xbib.elasticsearch.jdbc.strategy.standard.StandardSource;
 import org.xbib.elasticsearch.common.util.IndexableObject;
@@ -42,7 +42,7 @@ import java.util.List;
  */
 public class ColumnSource<C extends ColumnContext> extends StandardSource<C> {
 
-    private static final Logger logger = LogManager.getLogger("importer.jdbc.source.column");
+    private static final Logger logger = LoggerFactory.getLogger("importer.jdbc.source.column");
 
     private static final String WHERE_CLAUSE_PLACEHOLDER = "$where";
 

--- a/src/main/java/org/xbib/elasticsearch/jdbc/strategy/standard/StandardContext.java
+++ b/src/main/java/org/xbib/elasticsearch/jdbc/strategy/standard/StandardContext.java
@@ -15,8 +15,6 @@
  */
 package org.xbib.elasticsearch.jdbc.strategy.standard;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.elasticsearch.common.joda.FormatDateTimeFormatter;
 import org.elasticsearch.common.joda.Joda;
 import org.elasticsearch.common.settings.Settings;
@@ -24,6 +22,8 @@ import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.support.XContentMapValues;
 import org.joda.time.DateTime;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.xbib.elasticsearch.common.metrics.MetricsLogger;
 import org.xbib.elasticsearch.common.util.LocaleUtil;
 import org.xbib.elasticsearch.common.util.StrategyLoader;
@@ -53,7 +53,7 @@ import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
  */
 public class StandardContext<S extends JDBCSource> implements Context<S, Sink> {
 
-    private final static Logger logger = LogManager.getLogger("importer.jdbc.context.standard");
+    private final static Logger logger = LoggerFactory.getLogger("importer.jdbc.context.standard");
 
     private Settings settings;
 

--- a/src/main/java/org/xbib/elasticsearch/jdbc/strategy/standard/StandardSink.java
+++ b/src/main/java/org/xbib/elasticsearch/jdbc/strategy/standard/StandardSink.java
@@ -15,8 +15,6 @@
  */
 package org.xbib.elasticsearch.jdbc.strategy.standard;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.elasticsearch.action.admin.indices.alias.get.GetAliasesAction;
 import org.elasticsearch.action.admin.indices.alias.get.GetAliasesResponse;
 import org.elasticsearch.action.delete.DeleteRequest;
@@ -33,6 +31,8 @@ import org.elasticsearch.index.VersionType;
 import org.elasticsearch.indices.IndexAlreadyExistsException;
 import org.joda.time.DateTime;
 import org.joda.time.format.DateTimeFormat;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.xbib.elasticsearch.common.metrics.SinkMetric;
 import org.xbib.elasticsearch.common.util.ControlKeys;
 import org.xbib.elasticsearch.common.util.IndexableObject;
@@ -56,7 +56,7 @@ import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
  */
 public class StandardSink<C extends StandardContext> implements Sink<C> {
 
-    private final static Logger logger = LogManager.getLogger("importer.jdbc.sink.standard");
+    private final static Logger logger = LoggerFactory.getLogger("importer.jdbc.sink.standard");
 
     protected C context;
 

--- a/src/main/java/org/xbib/elasticsearch/jdbc/strategy/standard/StandardSource.java
+++ b/src/main/java/org/xbib/elasticsearch/jdbc/strategy/standard/StandardSource.java
@@ -15,11 +15,11 @@
  */
 package org.xbib.elasticsearch.jdbc.strategy.standard;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.elasticsearch.common.unit.TimeValue;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.xbib.elasticsearch.common.keyvalue.KeyValueStreamListener;
 import org.xbib.elasticsearch.common.util.ExceptionFormatter;
 import org.xbib.elasticsearch.common.metrics.SourceMetric;
@@ -71,7 +71,7 @@ import java.util.TimeZone;
  */
 public class StandardSource<C extends StandardContext> implements JDBCSource<C> {
 
-    private final static Logger logger = LogManager.getLogger("importer.jdbc.source.standard");
+    private final static Logger logger = LoggerFactory.getLogger("importer.jdbc.source.standard");
 
     protected C context;
 

--- a/src/main/java/org/xbib/pipeline/AbstractPipeline.java
+++ b/src/main/java/org/xbib/pipeline/AbstractPipeline.java
@@ -1,8 +1,8 @@
 
 package org.xbib.pipeline;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.TimeUnit;
@@ -16,7 +16,7 @@ import java.util.concurrent.TimeUnit;
 public abstract class AbstractPipeline<R extends PipelineRequest>
         implements Pipeline<R> {
 
-    private final static Logger logger = LogManager.getLogger(AbstractPipeline.class);
+    private final static Logger logger = LoggerFactory.getLogger(AbstractPipeline.class);
 
     private BlockingQueue<R> queue;  //= new SynchronousQueue<>(true);
 

--- a/src/main/java/org/xbib/tools/JDBCImporter.java
+++ b/src/main/java/org/xbib/tools/JDBCImporter.java
@@ -15,10 +15,10 @@
  */
 package org.xbib.tools;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.xbib.elasticsearch.common.cron.CronExpression;
 import org.xbib.elasticsearch.common.cron.CronThreadPoolExecutor;
 import org.xbib.elasticsearch.common.util.StrategyLoader;
@@ -54,7 +54,7 @@ public class JDBCImporter
         extends AbstractPipeline<SettingsPipelineRequest>
         implements Runnable, CommandLineInterpreter {
 
-    private final static Logger logger = LogManager.getLogger("importer.jdbc");
+    private final static Logger logger = LoggerFactory.getLogger("importer.jdbc");
 
     private Context context;
 

--- a/src/test/java/org/xbib/elasticsearch/common/util/GeometryTests.java
+++ b/src/test/java/org/xbib/elasticsearch/common/util/GeometryTests.java
@@ -3,9 +3,9 @@ package org.xbib.elasticsearch.common.util;
 import com.spatial4j.core.context.SpatialContext;
 import com.spatial4j.core.context.jts.JtsSpatialContext;
 import com.spatial4j.core.shape.Shape;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
@@ -15,7 +15,7 @@ import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
 
 public class GeometryTests {
 
-    protected final static Logger logger = LogManager.getLogger("test.geo");
+    protected final static Logger logger = LoggerFactory.getLogger("test.geo");
 
     @Test
     public void convert() throws ParseException, IOException {

--- a/src/test/java/org/xbib/elasticsearch/jdbc/strategy/column/ColumnStrategySourceTests.java
+++ b/src/test/java/org/xbib/elasticsearch/jdbc/strategy/column/ColumnStrategySourceTests.java
@@ -1,10 +1,10 @@
 package org.xbib.elasticsearch.jdbc.strategy.column;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
 import org.joda.time.DateTime;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.testng.annotations.Parameters;
 import org.testng.annotations.Test;
 import org.xbib.elasticsearch.jdbc.strategy.Context;
@@ -25,7 +25,7 @@ import java.util.Random;
 
 public class ColumnStrategySourceTests extends AbstractColumnStrategyTest {
 
-    private final static Logger logger = LogManager.getLogger("test.column.source");
+    private final static Logger logger = LoggerFactory.getLogger("test.column.source");
 
     private Random random = new Random();
 

--- a/src/test/java/org/xbib/elasticsearch/jdbc/strategy/mock/MockSink.java
+++ b/src/test/java/org/xbib/elasticsearch/jdbc/strategy/mock/MockSink.java
@@ -15,8 +15,8 @@
  */
 package org.xbib.elasticsearch.jdbc.strategy.mock;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.xbib.elasticsearch.common.metrics.SinkMetric;
 import org.xbib.elasticsearch.common.util.IndexableObject;
 import org.xbib.elasticsearch.jdbc.strategy.Sink;
@@ -27,7 +27,7 @@ import java.util.TreeMap;
 
 public class MockSink implements Sink<MockContext> {
 
-    private final static Logger logger = LogManager.getLogger(MockSink.class);
+    private final static Logger logger = LoggerFactory.getLogger(MockSink.class);
 
     private Map<IndexableObject, String> data;
 

--- a/src/test/java/org/xbib/elasticsearch/jdbc/strategy/standard/AbstractSinkTest.java
+++ b/src/test/java/org/xbib/elasticsearch/jdbc/strategy/standard/AbstractSinkTest.java
@@ -15,9 +15,9 @@
  */
 package org.xbib.elasticsearch.jdbc.strategy.standard;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.elasticsearch.common.settings.Settings;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Optional;
@@ -45,7 +45,7 @@ import java.util.UUID;
 
 public abstract class AbstractSinkTest extends NodeTestUtils {
 
-    protected final static Logger logger = LogManager.getLogger("test.target");
+    protected final static Logger logger = LoggerFactory.getLogger("test.target");
 
     protected static JDBCSource source;
 

--- a/src/test/java/org/xbib/elasticsearch/jdbc/strategy/standard/AbstractSourceTest.java
+++ b/src/test/java/org/xbib/elasticsearch/jdbc/strategy/standard/AbstractSourceTest.java
@@ -15,8 +15,8 @@
  */
 package org.xbib.elasticsearch.jdbc.strategy.standard;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
@@ -44,7 +44,7 @@ import java.util.UUID;
 
 public abstract class AbstractSourceTest extends Assert {
 
-    protected final static Logger logger = LogManager.getLogger("test.source");
+    protected final static Logger logger = LoggerFactory.getLogger("test.source");
 
     protected static JDBCSource source;
 

--- a/src/test/java/org/xbib/elasticsearch/jdbc/strategy/standard/StandardSourceTests.java
+++ b/src/test/java/org/xbib/elasticsearch/jdbc/strategy/standard/StandardSourceTests.java
@@ -15,8 +15,8 @@
  */
 package org.xbib.elasticsearch.jdbc.strategy.standard;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.testng.annotations.Optional;
 import org.testng.annotations.Parameters;
 import org.testng.annotations.Test;
@@ -37,7 +37,7 @@ import java.util.List;
 
 public class StandardSourceTests extends AbstractSourceTest {
 
-    private static final Logger logger = LogManager.getLogger(StandardSourceTests.class.getName());
+    private static final Logger logger = LoggerFactory.getLogger(StandardSourceTests.class.getName());
 
     @Override
     public JDBCSource newSource() {

--- a/src/test/java/org/xbib/elasticsearch/util/TestListener.java
+++ b/src/test/java/org/xbib/elasticsearch/util/TestListener.java
@@ -15,15 +15,15 @@
  */
 package org.xbib.elasticsearch.util;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.testng.ITestContext;
 import org.testng.ITestListener;
 import org.testng.ITestResult;
 
 public class TestListener implements ITestListener {
 
-    private final Logger logger = LogManager.getLogger("test.Listener");
+    private final Logger logger = LoggerFactory.getLogger("test.Listener");
 
     @Override
     public void onTestStart(ITestResult result) {


### PR DESCRIPTION
- Move logging to slf4j simplifying integration with other software
- Keep log4j as logger for distribution and tests
