### PR TITLE
failfast if can't get db connection for reading

### DIFF
--- a/src/main/java/org/xbib/elasticsearch/jdbc/strategy/standard/StandardSource.java
+++ b/src/main/java/org/xbib/elasticsearch/jdbc/strategy/standard/StandardSource.java
@@ -687,6 +687,8 @@ public class StandardSource<C extends StandardContext> implements JDBCSource<C> 
                             .shouldDetectGeo(shouldDetectGeo())
                             .shouldDetectJson(shouldDetectJson());
                     merge(command, results, listener);
+                } else {
+                    throw new SQLException("can't connect to source " + url);
                 }
             } else {
                 // use write connection


### PR DESCRIPTION
Fail-fast if something wrong while connecting to db. Now it doesn't throw any error when for example db credentials are wrong. 
