### PR TITLE
fix the number of threads continue to grow  problem

### DIFF
--- a/src/main/java/org/xbib/tools/JDBCImporter.java
+++ b/src/main/java/org/xbib/tools/JDBCImporter.java
@@ -152,6 +152,14 @@ public class JDBCImporter
             logger.error(e.getMessage(), e);
         } finally {
             try {
+            	executorService.shutdown();
+                if (!executorService.awaitTermination(15, TimeUnit.SECONDS)) {
+                    executorService.shutdownNow();
+                    if (!executorService.awaitTermination(15, TimeUnit.SECONDS)) {
+                        throw new IOException("pool did not terminate");
+                    }
+                }
+            	
                 if (context != null) {
                     context.shutdown();
                     context = null;


### PR DESCRIPTION
https://github.com/jprante/elasticsearch-jdbc/issues/937

Using Cron expression import data,  will continue to create new threads , and not shutdown.
